### PR TITLE
ci: add preview and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: publish
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup node 18 env
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: "npm"
+
+      - name: build
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install
+          npm run build
+
+      - name: Publish to OSS
+        uses: tvrcgo/oss-action@master
+        with:
+          key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          region: ${{ secrets.OSS_REGION }}
+          bucket: ${{ secrets.OSS_BUCKET }}
+          assets: |
+            ./build/**:${{ secrets.OSS_TARGET_PATH }}

--- a/.github/workflows/pull_preview.yml
+++ b/.github/workflows/pull_preview.yml
@@ -1,0 +1,77 @@
+name: pr_test
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  preview:
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check comment command
+        uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: '^/preview$'
+
+      - uses: actions/github-script@v3
+        id: get-pr
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        with:
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            }
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            try {
+              const result = await github.pulls.get(request)
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+
+      - name: Check out pull request head
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+          ref: ${{ fromJSON(steps.get-pr.outputs.result).head.sha }}
+
+      - name: Setup node 18 env
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: "npm"
+
+      - name: Build the website
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
+          npm install
+          npm run build
+
+      - name: Upload to OSS
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        uses: tvrcgo/oss-action@master
+        with:
+          key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          region: ${{ secrets.OSS_REGION }}
+          bucket: ${{ secrets.OSS_BUCKET }}
+          assets: |
+            ./build/**:${{ secrets.OSS_TARGET_PATH }}pull_${{ github.event.issue.number }}/
+
+      - name: Create comment
+        if: ${{ steps.regex-match.outputs.match != '' }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: 🪧The website for this PR is deployed at https://open-digger.cn${{ secrets.OSS_TARGET_PATH }}pull_${{ github.event.issue.number }}/


### PR DESCRIPTION
## Description

This PR includes 2 workflows:

- `pull_preview` which allows `maintainers` to use `/preview` command to build and deploy a preview website for PRs.
- `publish` which will automatically publish the website to OSS after push on master branch

## Resolved issues

Closes #17 

### Before submitting the PR, please take the following into consideration
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.