### PR TITLE
fix: fix base url for preview command

### DIFF
--- a/.github/workflows/pull_preview.yml
+++ b/.github/workflows/pull_preview.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
           npm install
-          npm run build
+          BASE_URL=/pull_${{ github.event.issue.number }}/ npm run build
 
       - name: Upload to OSS
         if: ${{ steps.regex-match.outputs.match != '' }}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ const config = {
   tagline: 'Open Source Analysis Platform',
   favicon: 'img/favicon.ico',
   url: 'https://open-digger.cn',
-  baseUrl: '/',
+  baseUrl: process.env.BASE_URL || '/',
 
   scripts: [
     {
@@ -75,7 +75,7 @@ const config = {
 
   themes: ['@docusaurus/theme-mermaid'],
   markdown: {
-    mermaid: true, 
+    mermaid: true,
   },
 
   themeConfig:

--- a/i18n/en/docusaurus-plugin-content-docs/current/user_docs/intro.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/user_docs/intro.md
@@ -310,15 +310,15 @@ OpenDigger community also open to inter-community cooperation events, like conte
 
 ### GitHub Event Log
 
-We use [GHArchive](https://www.gharchive.org/) as our data source for GitHub event logs and the data service is provided by [clickhouse](https://clickhouse.tech/) cluster cloud service. For data details, please check the [data](/en/docs/user_docs/intro) docs.
+We use [GHArchive](https://www.gharchive.org/) as our data source for GitHub event logs and the data service is provided by [clickhouse](https://clickhouse.tech/) cluster cloud service. For data details, please check the [data](/docs/user_docs/intro) docs.
 
 ### Labeled Data
 
-We are collecting labeled data for more deeper analysis. You can view the corresponding data in the `labeled_data` folder. For more details, please check [labeled_data](/en/docs/user_docs/intro) docs.
+We are collecting labeled data for more deeper analysis. You can view the corresponding data in the `labeled_data` folder. For more details, please check [labeled_data](/docs/user_docs/intro) docs.
 
 ### Sample Data Usage
 
-OpenDigger provides ClickHouse sample data and Jupyter notebook image to run OpenDigger in local environment, please refer to [sample data doc](/en/docs/user_docs/intro).
+OpenDigger provides ClickHouse sample data and Jupyter notebook image to run OpenDigger in local environment, please refer to [sample data doc](/docs/user_docs/intro).
 
 ## Communication
 


### PR DESCRIPTION
## Description

This PR will fix the base URL config in the `/preview` command.

The config will read the env first to set the base URL, so in the action, we set the env to `pull_${pull_number}`, so the deployed website will use this as the base URL which not break all the relative links in the website.

## Resolved issues

Closes #26 

### Before submitting the PR, please take the following into consideration
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. If you don't have an issue, please create one.
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Resolve merge conflicts (if any).
- [x] Make sure that the current branch is upto date with the `main` branch.