### PR TITLE
docs: EN variant translation added for 2x blogs

### DIFF
--- a/i18n/en/docusaurus-plugin-content-blog/2024-11-6-open-source-monthly-insight-report/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-blog/2024-11-6-open-source-monthly-insight-report/index.mdx
@@ -1,54 +1,54 @@
 ---
-title: 2024 年 10 月开源生态数据洞察报告
+title: October 2024 Open Source Ecosystem Data Insight Report
 authors: [zsy, ww]
 slug: 2024-11-6-open-source-monthly-insight-report
 ---
 
-> OpenRank 指标是对工信部电子标准院的“信息技术 开源治理”系列标准中评价指标的开源实现，能够有效反映开源项目在开发者中的协作影响力，从而帮助我们了解开源世界，发现开源趋势，洞察开源事件。
+> The OpenRank indicator is an open source implementation of the evaluation indicators in the "Information Technology Open Source Governance" series of standards of the Electronic Standards Institute of the Ministry of Industry and Information Technology. It can effectively reflect the collaborative influence of open source projects among developers, thereby helping us understand the open source world, discover open source trends, and gain insight into open source events.
 
-# 本月 OpenRank 增长热点洞察
+# This Month's OpenRank Growth Hotspot Insights
 
-## 热点事件1：Linux 移除俄罗斯维护者，华为发布原生鸿蒙操作系统
+## Hot Event 1: Linux Removes Russian Maintainers, Huawei Releases Native HarmonyOS
 
-- 数据事实：根据 OpenDigger 数据，OpenHarmony 自 2019 年 8 月开源以来，OpenRank 成长迅速，已经成为中国排名第一的开源社区。目前 OpenHarmony 社区项目主要托管于 Gitee 平台，共计仓库数超 2000 个，总计贡献者超 8000 人，社区活跃开发者数量超 15000 人。有包括润和软件、软通动力、深开鸿、九联科技（按贡献者数量排名）等在内的 70 多家科技单位参与共建。
+- Data Facts: According to OpenDigger data, OpenHarmony has rapidly grown since its open-source release in August 2019, becoming the top-ranked open-source community in China. Currently, OpenHarmony projects are primarily hosted on the Gitee platform, with over 2,000 repositories, more than 8,000 contributors, and over 15,000 active developers. More than 70 tech companies, including Ruyi Software, Softpower Technology, Shencanhong, and Jolian Technology, are involved in its development.
 
-- 详情分析：在 2024 年 10 月下旬，Linux 社区由于“合规性要求”，从 Linux 内核维护者名单中移除了十余名俄罗斯开发者，Linus 在随后的邮件列表中对其他开发者的质疑作出了强硬回复。此事件在开源领域引起了广泛关注，凸显了地缘政治对开源技术社区影响的日益加深。事实上，技术领域受地缘政治影响的现象并不新鲜，早在 2019 年 5 月，华为就因被美国商务部列入实体清单而无法使用谷歌开发的安卓操作系统。作为应对，华为在同年 8 月推出了鸿蒙操作系统，并将其核心代码以 OpenHarmony 项目的形式开源，并于 2020 年 5 月捐赠给开放原子开源基金会。经过五年多的发展，OpenHarmony 已成为中国 OpenRank 排名最高的开源项目群。2024 年 10 月底，华为基于 OpenHarmony 的研发成果，正式发布了完全自主研发的原生鸿蒙系统，标志着 OpenHarmony 项目的成熟。
+- Detailed Analysis: In late October 2024, Linux removed over a dozen Russian developers from its kernel maintainer list due to "compliance requirements." Linus Torvalds responded firmly to other developers' questions in a subsequent mailing list. This event drew significant attention in the open-source community, highlighting the increasing impact of geopolitics on open-source technology. In May 2019, Huawei was added to the US Entity List, preventing it from using Google's Android OS. In response, Huawei released HarmonyOS in August 2019 and open-sourced its core code as the OpenHarmony project, donating it to the OpenAtom Open Source Foundation in May 2020. After over five years of development, OpenHarmony has become the highest-ranked open-source project group in China. In late October 2024, Huawei released a fully independent, natively developed HarmonyOS based on OpenHarmony's development, marking the project's maturity.
 
-- 作者点评：技术本身无国界，但技术从业者有国籍。在国际局势发生重大变化的背景下，我们既需保持开放合作的姿态，也必须随时准备主导和发展自己的核心技术领域。只有这样，我们才能借助科技的力量推动国家发展，并确保在全球竞争中具有强劲的竞争力。
+- Author's Comments: While technology itself is borderless, technologists have nationalities. In the face of significant geopolitical changes, we must maintain an open and cooperative stance while being prepared to lead and develop our core technologies. Only then can we leverage technology to drive national development and ensure strong global competitiveness.
 
-- 进阶阅读：
-  - OpenHarmony 仓库地址：https://gitee.com/openharmony
-  - Linux 移除俄罗斯维护者相关新闻：https://www.infoq.cn/article/PGmRDMhjjINXafmHM0bI
-  - 原生鸿蒙发布新闻：http://cq.people.com.cn/n2/2024/1023/c365412-41017916.html
+- Further Reading:
+  - OpenHarmony Repository: https://gitee.com/openharmony
+  - News on Linux Removing Russian Maintainers: https://www.infoq.cn/article/PGmRDMhjjINXafmHM0bI
+  - Native HarmonyOS Release News: http://cq.people.com.cn/n2/2024/1023/c365412-41017916.html
 
-## 热点事件2：开源之夏收官在即，全球暑期活动异彩纷呈
+## Hot Event 2: Open Source Summer Programs Conclude, Global Summer Activities Thrive
 
-- 数据事实：根据 OpenDigger 数据，由于受到十一国庆长假影响，中国大部分项目十月的 OpenRank 会出现普降。然而由于 OSPP、GSoC 等项目的火热，今年参与的相关的项目在 10 月总体而言有逆势 3.5% 的增长，上千人参与到暑期活动之中。
+- Data Facts: According to OpenDigger data, due to the impact of the National Day holiday in China, most projects experienced a decline in OpenRank during October. However, due to the popularity of OSPP and GSoC, related projects saw an overall increase of 3.5%, with thousands of participants involved in summer activities.
 
-- 详情分析：OSPP（开源之夏）和 GSoC（Google 编程之夏）在十月都迎来了收官，据官网数据显示，OSPP 和 GSoC 2024 年的项目数量都再创新高，分别达到了 561 个和 1133 个项目。根据 OpenDigger 数据洞察显示，除上述两个耳熟能详的暑期项目外，此类暑期期间面向高校学生群体的开源活动在全球各地也越来越多涌现出来。如在印度发起的 GSSoC24（GirlScript 编程之夏）项目也在十月正式启动，其发放证书的仓库中有超过 2000 名学生进行登记，使得该仓库被数据洞察注意到。而由韩国的 Woowa 社区发起编程培训课程也优先针对学生群体，因此暑期期间格外活跃，在他们的 GitHub 组织中，涉及到 Java、Android 和前端的应用开发学习项目，相关的 10 个学习仓库在 2024 年 10 月共收到了超过 4500 个学习 PR，而且学习讨论异常热烈，有超过 28000 个 PR Review 评论，因此多个仓库登上 OpenLeaderboard 十月全球榜。
+- Detailed Analysis: Both OSPP (Open Source Promotion Plan) and GSoC (Google Summer of Code) concluded in October. According to official data, both programs set new records in 2024, with 561 and 1,133 projects, respectively. OpenDigger data shows that similar summer programs targeting college students are emerging globally. For instance, the GSSoC24 (GirlScript Summer of Code) program launched in India in October, with over 2,000 students registering for certificates. Additionally, Woowa Brothers in South Korea initiated programming training courses targeting students, with over 4,500 learning PRs and 28,000 PR review comments across 10 learning repositories in October, placing multiple repositories on the global OpenLeaderboard.
 
-- 作者点评：近年来，面向高校学生的开源暑期活动越来越多，形式也越来越丰富。开源不仅孕育了海量优秀的软件，也为高校学生提供了大量的编程学习和实战的机会，此类的活动和课程已经成为推动学生技术成长和创新能力发展的重要平台。
+- Author's Comments: In recent years, open-source summer programs for college students have become more numerous and diverse. These programs not only produce excellent software but also provide students with valuable coding and practical experience, becoming important platforms for their technical growth and innovation.
 
-- 进阶阅读：
-  - OSPP 官网：https://summer-ospp.ac.cn/
-  - GSoC 官网：https://summerofcode.withgoogle.com/
+- Further Reading:
+  - OSPP Official Website: https://summer-ospp.ac.cn/
+  - GSoC Official Website: https://summerofcode.withgoogle.com/
 
-# 本月推荐项目
+# Recommended Projects of the Month
 
 ## freeCodeCamp
 
-- freeCodeCamp 是一个非常受欢迎的在线学习平台，旨在通过交互式的学习方式教授编程和 web 开发技能。它是完全免费的，提供了丰富的课程资源，包括数千个编程挑战、项目、算法和前端开发实践。其主仓库以 40 万的 star 数常年稳居 GitHub star 榜第一。2024 年 10 月，freeCodeCamp 参与到了 Hacktoberfest 活动中，该活动为这个本就非常活跃的项目带来了更多的开发者，当月有 380 名开发者参与到协作之中，最终开出了 435 个 PR 并有 2200 多条讨论，助力该项目最终 OpenRank 当月增长 50% 定格 151。
-- 仓库地址：https://github.com/freeCodeCamp/freeCodeCamp
-- 点评：freeCodeCamp 和 Hacktoberfest 都是 2014 年开始的项目，历经十年发展，两个项目的结合依然可以迸发出强大的创造力。
+- freeCodeCamp is a popular online learning platform that teaches programming and web development skills through interactive methods. It offers free resources, including thousands of coding challenges, projects, algorithms, and front-end development practices. Its main repository has over 400,000 stars, consistently ranking first on GitHub's star chart. In October 2024, freeCodeCamp participated in Hacktoberfest, attracting more developers. During the month, 380 developers contributed, resulting in 435 PRs and over 2,200 discussions, boosting the project's OpenRank by 50% to 151.
+- Repository: https://github.com/freeCodeCamp/freeCodeCamp
+- Comment: Both freeCodeCamp and Hacktoberfest started in 2014, and their combination continues to inspire creativity after a decade of development.
 
 ## Bolt.new
 
-- 2024 年 10 月初，WebContainer 项目的开发公司 StackBlitz 发布了他们新产品 Bolt.new，该产品深度集成了基于大语言模型的 AI 助手和基于 WebContainer 技术的 Web IDE，因此可以在浏览器本地进行代码生成以及 Node.js 的代码运行，从而使得基于 Node.js 的软件项目可以完全在本地浏览器中完成开发、调试和部署的一站式工作。该产品的推出受到了众多开发者的追捧，其在 Twitter 上的发布贴有超 60 万次浏览，而该仓库仅开源一个月时间，收到了超过 6600 个 Star，超过 1100 名开发者参与到社区讨论和协作，最终 OpenRank 定格 163。
-- 仓库地址：https://github.com/stackblitz/bolt.new
-- 点评：随着大语言模型的出现，编程生产力得到了显著提升，而 WebContainer 等技术的发展则彻底改变了应用的运行和部署方式，使得服务器应用可以直接在浏览器中运行和调试。这两种技术的结合为开发者提供了前所未有的便利和体验，极大激发了他们的热情与创造力。
+- In early October 2024, StackBlitz, the company behind the WebContainer project, launched Bolt.new. This new product integrates AI assistants based on large language models with WebContainer technology, enabling local code generation and Node.js execution in the browser. This allows Node.js based software projects to be developed, debugged, and deployed entirely within the browser. The launch was well-received, with over 600,000 views on Twitter. Within a month, the repository received over 6,600 stars, and more than 1,100 developers participated in discussions and collaborations, resulting in an OpenRank of 163.
+- Repository: https://github.com/stackblitz/bolt.new
+- Comment: The emergence of large language models has significantly enhanced programming productivity, while WebContainer technology has revolutionized application deployment. Their combination provides unprecedented convenience and experience for developers, greatly inspiring their enthusiasm and creativity.
 
 ## Hackpad
 
-- Hackpad 是由全球各地的高中生极客组成的 Hack Club 发起的一个有趣的黑客松项目。Hackpad 开放一个仓库用于在活动期间接收任何开发者提交的迷你键盘的设计，包括 PCB 板设计、硬件模型设计以及对应的程序软件，从而可以创作出各种有趣的迷你键盘。而组织方则会在活动结束后对合入的方案制作实体键盘发放给参赛者。该仓库在 2024 年 10 月有 178 位参与者提交了 287 个 PR，也助力该仓库 OpenRank 定格 100 分。
-- 仓库地址：https://github.com/hackclub/hackpad
-- 点评：开源协作平台提供了全球性社区发展的沃土，而 Hack Club 这种由青少年组成的全球性技术社区让人眼前一亮，他们的组织中不乏有趣的想法和活动，让人看到了年轻人的想象力与执行力。在严肃的企业软件之外，也让人们意识到最初的黑客精神，就是 just for fun！
+- Hackpad is an interesting hackathon project initiated by Hack Club, a global community of high school hackers. The project invites developers to submit mini keyboard designs, including PCB designs, hardware models, and software programs, during the event. The organizers will produce physical keyboards based on the accepted designs and distribute them to participants. In October 2024, 178 participants submitted 287 PRs, contributing to the repository's OpenRank of 100.
+- Repository: https://github.com/hackclub/hackpad
+- Comment: Open-source collaboration platforms provide fertile ground for global community development. Hack Club, a global tech community of young students, stands out with creative ideas and activities, reminding us of the original hacker spirit: just for fun!

--- a/i18n/en/docusaurus-plugin-content-blog/2024-12-6-open-source-monthly-insight-report/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-blog/2024-12-6-open-source-monthly-insight-report/index.mdx
@@ -1,47 +1,47 @@
 ---
-title: 2024 年 11 月开源生态数据洞察报告
+title: November 2024 Open Source Ecosystem Data Insight Report
 authors: [zsy, ww]
 slug: 2024-12-6-open-source-monthly-insight-report
 ---
 
-> OpenRank 指标是对工信部电子标准院的“信息技术 开源治理”系列标准中评价指标的开源实现，能够有效反映开源项目在开发者中的协作影响力，从而帮助我们了解开源世界，发现开源趋势，洞察开源事件。
+> The OpenRank indicator is an open source implementation of the evaluation indicators in the "Information Technology Open Source Governance" series of standards of the Electronic Standards Institute of the Ministry of Industry and Information Technology. It can effectively reflect the collaborative influence of open source projects among developers, thereby helping us understand the open source world, discover open source trends, and gain insight into open source events.
 
-# 本月 OpenRank 增长热点洞察
+# This Month's OpenRank Growth Hotspot Insights
 
-## 热点事件1：BlueSky 爆火背后，美国大选与 AI 浪潮
+## Hot Event 1: BlueSky's Surge, Driven by US Elections and AI Wave
 
-- 数据事实：根据 OpenDigger 数据，GitHub 上 BlueSky 的多个仓库出现了数据激增，包括其自研的去中心化社交媒体协议仓库 atproto 和客户端仓库 social-app。其组织下所有仓库 11 月的活跃开发者总数同比增长 173% 达到 1082 人，所有仓库星标数增长 5.8k，OpenRank 总值同比增长 67%，达到了 340 分。
+- Data Facts: According to OpenDigger data, multiple BlueSky repositories on GitHub experienced a surge in activity. This includes their decentralized social media protocol repository, atproto, and the client repository, social-app. The total number of active developers across all repositories in November increased by 173% year-over-year to 1,082, with a total star increase of 5,800. The total OpenRank value increased by 67%, reaching 340 points.
 
-- 详情分析：BlueSky 是前 Twitter CEO 杰克·多尔西创建的一个独立项目，使用全新的自研 AT 社交网络协议开发，旨在实现一个去中心化的社交媒体。11 月 5 日美国大选以来，部分对大选结果不满的用户选择离开 Twitter 寻找新的社交平台，BlueSky 成为了他们的一个重要选项，而大选一周后，其客户端应用也登顶了苹果 App Store 美国区的免费榜应用榜榜首。另外 11 月 16 日，Twitter 平台更新其隐私权政策（Privacy Policy），允许三方平台利用其用户数据进行生成式 AI 训练，而随后 BlueSky 官方发文表示不会使用用户数据进行生成式 AI 的训练，该事件也导致大量高质量内容创作者开始迁移到 BlueSky 平台以保护自己生产的数字化内容。该平台截止 2024 年 9 月全平台注册用户约 1000 万，11 月以来多个事件导致其平台用户激增，截止 11 月 20 日，该平台注册用户数已突破 2000 万。
+- Detailed Analysis: BlueSky is an independent project created by former Twitter CEO Jack Dorsey, using a newly developed AT social network protocol to achieve a decentralized social media platform. Following the US elections on November 5, some users dissatisfied with the election results chose to leave Twitter in search of new social platforms, with BlueSky becoming a significant option. A week after the election, its client app topped the free app charts in the US Apple App Store. Additionally, on November 16, Twitter updated its Privacy Policy to allow third-party platforms to use user data for generative AI training. In response, BlueSky officially stated that it would not use user data for generative AI training, leading many high-quality content creators to migrate to BlueSky to protect their digital content. The platform had approximately 10 million registered users as of September 2024, and various events in November led to a surge in users, with registered users exceeding 20 million by November 20.
 
-- 作者点评：技术世界从不是独立存在的，现实中的事件会以不同的方式反映到开源社区中。而生成式 AI 的火爆也开始使其底层矛盾愈加凸显，开发者和用户会用自己的真实行动来投票。
+- Author's Comments: The tech world is not isolated from real-world events, which can significantly impact the open-source community. The rise of generative AI has also highlighted underlying issues, with developers and users taking action to protect their interests.
 
-- 进阶阅读：
-  - Twitter 更新 Privacy Policy：https://privacy.x.com/en/blog/2024/updates-tos-privacy-policy
-  - BlueSky 对生成式 AI 的声明：https://bsky.app/profile/bsky.app/post/3layuzbto2c2x
-  - BlueSky 的 GitHub 主页：https://github.com/bluesky-social
+- Further Reading:
+  - Twitter Privacy Policy Update: https://privacy.x.com/en/blog/2024/updates-tos-privacy-policy
+  - BlueSky's Statement on Generative AI: https://bsky.app/profile/bsky.app/post/3layuzbto2c2x
+  - BlueSky GitHub Page: https://github.com/bluesky-social
 
-## 热点事件2：Redis 尝试控制周边项目，Valkey 社区持续增长
+## Hot Event 2: Redis Attempts to Control Peripheral Projects, Valkey Community Continues to Grow
 
-- 数据事实：根据 OpenDigger 数据，Redis 的 Rust 客户端仓库 rust-rs 在 2024 年 11 月活跃开发者数量增长 54% 达到 40 人，其中大部分参与了关于 Redis 公司希望其作者转让项目而引发的讨论 Issue。而 2024 年 3 月分叉的 Valkey 社区则持续增长，在各项数据层面都已全面超越 Redis 主仓库。
+- Data Facts: According to OpenDigger data, the number of active developers in Redis's Rust client repository, rust-rs, increased by 54% in November 2024 to 40, with many participating in discussions about Redis's request for the project's author to transfer control. Meanwhile, the Valkey community, which forked from Redis in March 2024, continues to grow, surpassing the main Redis repository in various metrics.
 
-- 详情分析：2024 年 11 月 25 日，Redis 的 Rust 客户端项目 rust-rs 的作者 Armin Ronacher 在仓库上开启了一个 Issue 讨论关于该项目与 Reids 公司的关系，称 Redis 公司要求将其项目控制权进行转让，而 Redis 的 PHP 客户端 Pedis 的维护者表示也收到了同样的要求。事实上这已经不是 Redis 公司第一尝试控制周边社区项目了，在 2020 年至 2024 年间 Redis 公司分别将 Redis 的社区客户端 Jedis、Redis-py 和 Lettuce 转移至其 GitHub 组织中。而与此同时也有开发者担忧社区客户端被 Redis 公司控制后新版本是否会与 Valkey 不再兼容。Valkey 是 2024 年 3 月 Redis 公司宣布修改其项目许可证后分叉出的社区，由原 Redis 项目中来自 AWS、阿里云、Google、腾讯云等云厂商的核心开发者牵头成立，目前已托管在 Linux 基金会中。在 Redis 社区分裂后，Valkey 项目稳定发展，而 Redis 项目已逐渐不再活跃，根据 OpenDigger 数据，11 月 Valkey 主仓库的 OpenRank 已达 71 分，而 Redis 的主仓库则从 3 月份的 62 分将至 27 分。
+- Detailed Analysis: On November 25, 2024, Armin Ronacher, the author of Redis's Rust client project rust-rs, opened an issue discussing Redis's request for control over the project. The maintainer of Redis's PHP client, Pedis, reported receiving a similar request. This is not Redis's first attempt to control community projects; between 2020 and 2024, Redis transferred several community clients, including Jedis, Redis-py, and Lettuce, to its GitHub organization. Meanwhile, there are concerns that new versions of community clients controlled by Redis may not be compatible with Valkey. Valkey is a community fork of Redis created in March 2024 after Redis announced changes to its project license. It is led by core developers from AWS, Alibaba Cloud, Google, and Tencent Cloud and is now hosted by the Linux Foundation. Since the Redis community split, Valkey has developed steadily, while Redis has become less active. According to OpenDigger data, Valkey's main repository OpenRank reached 71 points in November, while Redis's main repository dropped from 62 points in March to 27 points.
 
-- 作者点评：软件所有权不仅仅是代码的归属问题，更涉及到项目的可持续发展和社区的信任。当一个开源项目的所有权转移到一家商业公司手中时，社区成员往往会担心项目的中立性和开放性会受到影响。Redis 和 Valkey 的未来会向哪个方向发展，还需要进一步的跟踪观察。
+- Author's Comments: Software ownership involves more than just code; it affects a project's sustainability and community trust. When an open-source project's ownership is transferred to a commercial company, community members often worry about the project's neutrality and openness. The future development of Redis and Valkey remains to be seen.
 
-- 进阶阅读：
-  - redis-rs 仓库讨论 Issue：https://github.com/redis-rs/redis-rs/issues/1419
-  - valkey 仓库地址：https://github.com/valkey-io/valkey
-  - OpenDigger 关于 Redis 与 Valkey 的数据分析报告：https://open-digger.cn/blog/2024-04-04-redis-analysis
+- Further Reading:
+  - redis-rs Repository Discussion Issue: https://github.com/redis-rs/redis-rs/issues/1419
+  - Valkey Repository: https://github.com/valkey-io/valkey
+  - OpenDigger Analysis Report on Redis and Valkey: https://open-digger.cn/blog/2024-04-04-redis-analysis
 
-# 本月推荐项目
+# Recommended Projects of the Month
 
 ## Julia
 
-- Julia 是 2009 年开始开发的一款面向高性能数值分析和计算科学的动态编程语言，并在 2018 年发布了 1.0 版本。后续一直稳定的持续发展，随着语言内核的持续完善，目前的开发重心也逐渐转向上层的标准库支持。2024 年 11 月，社区将线性代数相关的标准库从主仓库中抽离为一个独立仓库并转移了与其相关的上千个 Issue 到新仓库中。由于这种迁移在日志中会被记录为新建 Issue，因此该仓库也被数据洞察注意到。而 Julia 本身的发展也非常稳定，截止 2024 年 11 月，其所有仓库 OpenRank 值已达到 242 分。
-- 仓库地址：https://github.com/JuliaLang/julia
+- Julia is a high-performance dynamic programming language for numerical analysis and computational science, first developed in 2009 and released version 1.0 in 2018. With continuous improvements to its language core, the development focus has shifted towards supporting standard libraries. In November 2024, the community moved linear algebra-related standard libraries to a separate repository, transferring thousands of related issues. This migration was noted in logs as new issues, drawing attention from data insights. Julia's development remains stable, with an OpenRank value of 242 across all repositories as of November 2024.
+- Repository: https://github.com/JuliaLang/julia
 
 ## Zen Browser
 
-- Zen 浏览器是一个基于 Firefox 内核开发的开源浏览器，自 2024 年 4 月开源，8 月后突然火爆，11 月仓库参与开发者人数达 882 人。该项目以其优秀的用户体验深受用户的喜爱，所有试用体验类文章都不乏溢美之词。如分屏显示功能作为受众多用户喜欢的一项功能，目前在 Chrome 浏览器中依然只能通过插件进行实现。根据 OpenDigger 数据，该仓库 11 月 OpenRank 值达 262 分，强势增长 48 位进入全球仓库 OpenRank 榜 63 名。
-- 仓库地址：https://github.com/zen-browser/desktop
+- Zen Browser is an open-source browser based on the Firefox engine, open-sourced in April 2024 and gaining popularity in August. In November, the repository had 882 participating developers. Known for its excellent user experience, the browser features a split-screen display, a popular feature not natively supported in Chrome. According to OpenDigger data, the repository's OpenRank value reached 262 in November, ranking 63rd globally.
+- Repository: https://github.com/zen-browser/desktop

--- a/i18n/en/docusaurus-plugin-content-blog/2025-1-6-open-source-monthly-insight-report/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-blog/2025-1-6-open-source-monthly-insight-report/index.mdx
@@ -1,46 +1,46 @@
 ---
-title: 2024 年 12 月开源生态数据洞察报告
+title: 2024 December Open Source Ecosystem Data Insight Report
 authors: [zsy, ww]
 slug: 2025-1-6-open-source-monthly-insight-report
 ---
 
-> OpenRank 指标是对工信部电子标准院的“信息技术 开源治理”系列标准中评价指标的开源实现，能够有效反映开源项目在开发者中的协作影响力，从而帮助我们了解开源世界，发现开源趋势，洞察开源事件。
+> The OpenRank indicator is an open source implementation of the evaluation indicators in the "Information Technology Open Source Governance" series of standards of the Electronic Standards Institute of the Ministry of Industry and Information Technology. It can effectively reflect the collaborative influence of open source projects among developers, thereby helping us understand the open source world, discover open source trends, and gain insight into open source events.
 
-# 本月 OpenRank 增长热点洞察
+# This Month's OpenRank Growth Hotspot Insights
 
-## 热点事件1：Ghostty 重磅发布，归来仍少年
+## Hot Event 1: Ghostty is released, and it is still young again
 
-- 数据事实：根据 OpenDigger 数据显示，Ghostty 项目在发布后的 5 天内，该仓库就吸引到超过 530 位开发者参与，超 1000 条讨论，获得超过 1.6 万 Star，OpenRank 强势突破 100，定格 105。
+- Data Facts: According to OpenDigger data, within 5 days of its release, the Ghostty project attracted over 530 developers, more than 1,000 discussions, and gained over 16,000 stars. Its OpenRank surged past 100, settling at 105.
 
-- 详情分析：Ghostty 是一款运行在 MacOS 或 Linux 系统上的终端模拟器，通过使用本地 GPU 资源可以使终端拥有更丰富的功能和流畅的使用体验。2024.12.26，Ghostty 项目经过 2 年多的私仓开发后终于开源并正式发布 1.0 版本，而其作者正是在 23 岁时创立了 HashiCorp 的 Mitchell Hashimoto。这位只想做码农的创始人在 2016 年辞去 CEO 的职务，担任 HashiCorp 的 CTO，2021 年底又辞去 CTO 职务回归个人程序员并于 2023 年底离开了他一手创建的开源上市公司。根据数据显示，Ghostty 项目创建于 2022 年 3 月，代码量超百万行，在最初的两年间，这个项目均由 Mitchell 一人独立开发，直到 2024 年年中才有其他开发者参与进来，但 Mitchell 依然是该项目的主力开发人员，贡献了项目超过 90% 的代码。
+- Detailed Analysis: Ghostty is a terminal emulator that runs on MacOS or Linux systems. By utilizing local GPU resources, it enhances terminal functionality and provides a smoother user experience. On December 26, 2024, after more than 2 years of private repository development, Ghostty was open-sourced and officially released version 1.0. The author, Mitchell Hashimoto, founded HashiCorp at the age of 23. He stepped down as CEO in 2016 to become the CTO and later resigned from the CTO position in late 2021 to return to personal programming. He left the company he founded at the end of 2023. Data shows that the Ghostty project was created in March 2022, with over a million lines of code. Initially, Mitchell developed the project alone for two years until mid-2024, when other developers joined. Mitchell remains the primary developer, contributing over 90% of the project's code.
 
-- 作者点评：作为创建了 HashiCorp 的创始人，Mitchell 热爱代码，是 Vagrant、Consul、Terraform、Vault 等一众云计算知名开源项目的创始工程师和核心开发者。开源世界代码为王，虽已是亿万富翁，但他还是那个热爱代码的少年，这或许也是这个项目备受开发者关注的重要因素之一。
+- Author's Comments: As the founder of HashiCorp, Mitchell loves coding and is the founding engineer and core developer of well-known open-source projects like Vagrant, Consul, Terraform, and Vault. Despite being a multi-millionaire, his passion for coding remains unchanged, which is likely a significant factor in the project's popularity among developers.
 
-- 进阶阅读：
-  - Ghostty 项目仓库：https://github.com/ghostty-org/ghostty
-  - Ghostty 项目 Release 博客：https://mitchellh.com/writing/ghostty-1-0-reflection
+- Further Reading:
+  - Ghostty Project Repository: https://github.com/ghostty-org/ghostty
+  - Ghostty Project Release Blog: https://mitchellh.com/writing/ghostty-1-0-reflection
 
-## 热点事件2：生成式 AI 赋能具身智能，Genesis 正式发布
+## Hot Event 2: Generative AI Empowers Embodied Intelligence, Genesis Officially Released
 
-- 数据事实：根据 OpenDigger 数据显示，Genesis 项目自 2024.12.19 发布以来，该仓库在 10 天内吸引到超过 500 位开发者参与讨论，有 21 人成为项目贡献者，获得近 2 万 Star，OpenRank 定格 85。
+- Data Facts: According to OpenDigger data, since its release on December 19, 2024, the Genesis project attracted over 500 developers within 10 days, with 21 contributors and nearly 20,000 stars. Its OpenRank settled at 85.
 
-- 详情分析：Genesis 是一个结合了生成模型能力的具身智能研究平台，这个研究平台由通用物理引擎、机器人仿真平台、照片级渲染系统和数据生成引擎构成，而其中的数据生成引擎使用了生成式 AI 技术，可以将自然语言转换成各类不同模块的训练数据。该项目由 MIT-IBM 沃森人工智能实验室的首席科学家淦创博士带领的团队所开发，该团队在 2023 年底发表论文介绍了一个利用生成式 AI 技术为机器人提供无限学习数据并全自动化训练的框架 RoboGen，引发了全球关注。经过一年多的开发，RoboGen 框架正式开源为具身智能研究平台 Genesis 并引爆全网。
+- Detailed Analysis: Genesis is a research platform for embodied intelligence that integrates generative model capabilities. It consists of a general-purpose physics engine, robot simulation platform, photorealistic rendering system, and data generation engine powered by generative AI technology. This engine converts natural language into training data for various modules. The project is developed by a team led by Dr. Chan, Chief Scientist at the MIT-IBM Watson AI Lab. In late 2023, the team published a paper introducing RoboGen, a framework that uses generative AI to provide unlimited learning data for robots and automate training. After over a year of development, RoboGen was open-sourced as the embodied intelligence research platform Genesis, gaining widespread attention.
 
-- 作者点评：具身智能作为人工智能领域的前沿研究方向，其相关的开源研究平台并不多，2019 年由 Facebook 开源的 Habitat 平台是标志性项目之一。而生成式 AI 爆发以来，不少科学家也在研究如何将该技术应用于具身智能领域并加速智能机器人的发展，淦创博士的团队在发表论文后基于扎实的理论基础潜心打造科研平台，深度融合生成式 AI 技术，相信未来在该领域会有突出的贡献。
+- Author's Comments: Embodied intelligence is a cutting-edge research area in artificial intelligence, with few open-source research platforms available. Facebook's Habitat platform, open-sourced in 2019, is a notable example. With the rise of generative AI, scientists are exploring its application in embodied intelligence to accelerate the development of intelligent robots. Dr. Chan's team, building on a solid theoretical foundation, has integrated generative AI technology into their research platform, which is expected to make significant contributions in this field.
 
-- 进阶阅读：
-  - Genesis 项目仓库：https://github.com/Genesis-Embodied-AI/Genesis
-  - Habitat 项目仓库：https://github.com/facebookresearch/habitat-sim
-  - Genesis 媒体文章：https://sawanrai777.medium.com/genesis-a-revolutionary-platform-for-physics-and-embodied-ai-fc85914e8249
+- Further Reading:
+  - Genesis Project Repository: https://github.com/Genesis-Embodied-AI/Genesis
+  - Habitat Project Repository: https://github.com/facebookresearch/habitat-sim
+  - Genesis Media Article: https://sawanrai777.medium.com/genesis-a-revolutionary-platform-for-physics-and-embodied-ai-fc85914e8249
 
-# 本月推荐项目
+# Recommended Projects of the Month
 
 ## eliza
 
-- eliza 是一个面向个人开发者的轻量级 AI 智能体框架，可赋能个人快速创建自己的 AI 智能体和工作流。该项目 2024.7 开源以来主要以开发为主，2024.12 全网爆火，Star 数已突破 1 万，12 月全月活跃开发者共计 441 人，OpenRank 已达到 149。
-- 仓库地址：https://github.com/elizaOS/eliza
+- eliza is a lightweight AI agent framework for individual developers, enabling quick creation of personal AI agents and workflows. Since its open-source release in July 2024, the project has focused on development and gained significant popularity in December 2024, with over 10,000 stars and 441 active developers in December. Its OpenRank has reached 149.
+- Repository: https://github.com/elizaOS/eliza
 
 ## blink.cmp
 
-- blink.cmp 是一款用于 Neovim 编辑器的代码补全插件，与目前流行 Copilot 不同，该插件是传统的基于文本索引和模糊检索的补全工具。该插件以高效为其特点，在 2 万索引量下可以做到毫秒级响应，因此受到 Neovim 用户的喜爱。该项目 2024.10 开源，12 月全月活跃开发者共计 294 人，OpenRank 来到了 108。
-- 仓库地址：https://github.com/Saghen/blink.cmp
+- blink.cmp is a code completion plugin for the Neovim editor, unlike the popular Copilot, it is a traditional text indexing and fuzzy search-based completion tool known for its efficiency. It can respond in milliseconds with an index size of 20,000, making it popular among Neovim users. The project was open-sourced in October 2024 and had 294 active developers in December, with an OpenRank of 108.
+- Repository: https://github.com/Saghen/blink.cmp

--- a/i18n/en/docusaurus-plugin-content-blog/2025-1-6-open-source-monthly-insight-report/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-blog/2025-1-6-open-source-monthly-insight-report/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 2024 December Open Source Ecosystem Data Insight Report
+title: December 2024 Open Source Ecosystem Data Insight Report
 authors: [zsy, ww]
 slug: 2025-1-6-open-source-monthly-insight-report
 ---

--- a/i18n/en/docusaurus-plugin-content-blog/2025-2-6-open-source-monthly-insight-report/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-blog/2025-2-6-open-source-monthly-insight-report/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 2025.1 Open Source Monthly Insight Report
+title: January 2025 Open Source Monthly Insight Report
 authors: [zsy, ww]
 slug: 2025-2-6-open-source-monthly-insight-report
 ---


### PR DESCRIPTION
## Description

Translated (`EN`) variants of the following 2x docs have been added.

- https://open-digger.cn/en/blog/2025-1-6-open-source-monthly-insight-report
- https://open-digger.cn/en/blog/2024-12-6-open-source-monthly-insight-report

## Partially Resolves

Tracking [messasge](https://opendigger.slack.com/archives/D072EA1QUJ1/p1740024606034799)  /  cc: @frank-zsy 

### Before submitting the PR, please take the following into consideration
- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs:`, or `refactor:`.
- [x] The description should clearly illustrate what problems it solves.
- [x] Ensure that the commit messages follow our guidelines.
- [x] Make sure that the current branch is upto date with the `main` branch.